### PR TITLE
update rxjs to version 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "js-yaml": "^3.8.4",
     "ramda": "^0.24.1",
-    "rxjs": "^5.4.0"
+    "rxjs": "^6.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Updates rxjs to version 6.

A review of the code indicates that none of the breaking changes in the library update require any modifications.